### PR TITLE
Add missing dependency

### DIFF
--- a/_posts/2017-01-18-ionic-2-e2e-testing.markdown
+++ b/_posts/2017-01-18-ionic-2-e2e-testing.markdown
@@ -16,7 +16,7 @@ Install dev dependencies
 
 <div class="highlighter-rouge">
 <pre class="lowlight">
-<code>npm install --save-dev angular-cli @angular/router connect jasmine-spec-reporter protractor serve-static ts-node</code>
+<code>npm install --save-dev angular-cli @angular/router connect jasmine-reporters jasmine-spec-reporter protractor serve-static ts-node</code>
 </pre>
 </div>
 


### PR DESCRIPTION
`npm run e2e` fails without `jasmine-reporters`:

```
[19:26:53] I/launcher - Running 1 instances of WebDriver
[19:26:53] I/direct - Using ChromeDriver directly...
[19:26:55] E/launcher - Error: Error: Cannot find module 'jasmine-reporters'
    at Function.Module._resolveFilename (module.js:489:15)
    at Function.Module._load (module.js:439:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at onPrepare (/user/protractor.conf.js:29:28)
    at q_1.Promise (/user/node_modules/protractor/built/util.js:46:49)
    at Function.promise (/user/node_modules/q/q.js:682:9)
    at Object.runFilenameOrFn_ (/user/node_modules/protractor/built/util.js:38:16)
    at plugins_.onPrepare.then (/user/node_modules/protractor/built/runner.js:98:27)
    at _fulfilled (/user/node_modules/q/q.js:834:54)
[17:36:35] E/launcher - Process exited with error code 100
```